### PR TITLE
Open Consent DateTime

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERPCHRG-PR-Consent.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERPCHRG-PR-Consent.json
@@ -51,7 +51,8 @@
         "id": "Consent.scope.coding",
         "path": "Consent.scope.coding",
         "min": 1,
-        "max": "1"
+        "max": "1",
+        "mustSupport": true
       },
       {
         "id": "Consent.scope.coding.system",
@@ -72,6 +73,7 @@
         "id": "Consent.category",
         "path": "Consent.category",
         "max": "1",
+        "mustSupport": true,
         "binding": {
           "strength": "required",
           "valueSet": "https://gematik.de/fhir/erpchrg/ValueSet/GEM_ERPCHRG_VS_ConsentType"
@@ -80,7 +82,8 @@
       {
         "id": "Consent.patient",
         "path": "Consent.patient",
-        "min": 1
+        "min": 1,
+        "mustSupport": true
       },
       {
         "id": "Consent.patient.identifier",
@@ -93,7 +96,8 @@
               "http://fhir.de/StructureDefinition/identifier-kvid-10"
             ]
           }
-        ]
+        ],
+        "mustSupport": true
       },
       {
         "id": "Consent.patient.identifier.assigner",

--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERPCHRG-PR-Consent.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERPCHRG-PR-Consent.json
@@ -116,7 +116,7 @@
       {
         "id": "Consent.dateTime",
         "path": "Consent.dateTime",
-        "min": 1
+        "mustSupport": true
       },
       {
         "id": "Consent.policyRule",

--- a/Resources/input/fsh/profiles/GEM_ERPCHRG_PR_Consent.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERPCHRG_PR_Consent.fsh
@@ -5,15 +5,15 @@ Id: GEM-ERPCHRG-PR-Consent
 * insert MetaProfile(GEM_ERPCHRG_PR_Consent)
 
 * status = #active (exactly)
-* scope.coding 1..1
+* scope.coding 1..1 MS
   * system = $cs-consent-scope (exactly)
   * code = #patient-privacy (exactly)
   * display = "Privacy Consent" (exactly)
 
-* category 1..1
+* category 1..1 MS
 * category from GEM_ERPCHRG_VS_ConsentType (required)
-* patient 1..1
-  * identifier 1..1
+* patient 1..1 MS
+  * identifier 1..1 MS
   * identifier only IdentifierKvid10
     * assigner MS
     * assigner.identifier MS

--- a/Resources/input/fsh/profiles/GEM_ERPCHRG_PR_Consent.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERPCHRG_PR_Consent.fsh
@@ -18,7 +18,7 @@ Id: GEM-ERPCHRG-PR-Consent
     * assigner MS
     * assigner.identifier MS
     * assigner.identifier only IdentifierIknr
-* dateTime 1..1
+* dateTime MS
 
 * policyRule MS
 * policyRule from v3-ActCode


### PR DESCRIPTION
This PR opens the .dateTime field on the Consent Resource.
This timestamp should be set by the receiving server, hence it does not need to be set by the client.

Resolves: #TMD-2664